### PR TITLE
FIX

### DIFF
--- a/account_invoice_rounding/__manifest__.py
+++ b/account_invoice_rounding/__manifest__.py
@@ -2,7 +2,7 @@
 # Copyright 2016 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
 {'name': 'Unit rounded invoice',
- 'version': '10.0.1.0.0',
+ 'version': '10.0.1.0.1',
  'category': 'Accounting',
  'author': "Camptocamp,Odoo Community Association (OCA)",
  'maintainer': 'Camptocamp',

--- a/account_invoice_rounding/models/account.py
+++ b/account_invoice_rounding/models/account.py
@@ -99,6 +99,8 @@ class AccountInvoice(models.Model):
         company = invoice.company_id
         round_method = company.tax_calculation_rounding_method
 
+        if not round_method:
+            return {}
         if round_method[:7] != 'swedish':
             return {}
         prec = obj_precision.precision_get('Account')


### PR DESCRIPTION
account_invoice_rounding/models/account.py", line 102, in _compute_swedish_rounding
    if round_method[:7] != 'swedish':
TypeError: 'bool' object has no attribute '__getitem__'

when no rounding method is set