### PR TITLE
[IMP] account_invoice_triple_discount: Simplify account.move.line algorithm

### DIFF
--- a/account_invoice_triple_discount/README.rst
+++ b/account_invoice_triple_discount/README.rst
@@ -74,6 +74,7 @@ Authors
 
 * QubiQ
 * Tecnativa
+* GRAP
 
 Contributors
 ~~~~~~~~~~~~

--- a/account_invoice_triple_discount/__init__.py
+++ b/account_invoice_triple_discount/__init__.py
@@ -1,1 +1,2 @@
 from . import models
+from .hooks import post_init_hook

--- a/account_invoice_triple_discount/__manifest__.py
+++ b/account_invoice_triple_discount/__manifest__.py
@@ -13,6 +13,7 @@
     "excludes": [
         "account_global_discount",
     ],
+    "post_init_hook": "post_init_hook",
     "data": ["report/invoice.xml", "views/account_move.xml"],
     "installable": True,
 }

--- a/account_invoice_triple_discount/__manifest__.py
+++ b/account_invoice_triple_discount/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "Account Invoice Triple Discount",
     "version": "16.0.2.0.0",
     "category": "Accounting & Finance",
-    "author": "QubiQ, Tecnativa, Odoo Community Association (OCA)",
+    "author": "QubiQ, Tecnativa, GRAP, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/account-invoicing",
     "license": "AGPL-3",
     "summary": "Manage triple discount on invoice lines",

--- a/account_invoice_triple_discount/hooks.py
+++ b/account_invoice_triple_discount/hooks.py
@@ -1,0 +1,17 @@
+# Copyright 2024-Today - Sylvain Le GAL (GRAP)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+import logging
+
+_logger = logging.getLogger(__name__)
+
+
+def post_init_hook(cr, registry):
+    _logger.info("Initializing column discount1 on table account_move_line")
+    cr.execute(
+        """
+            UPDATE account_move_line
+            SET discount1 = discount
+            WHERE discount != 0
+        """
+    )

--- a/account_invoice_triple_discount/migrations/16.0.2.0.0/post-migrate.py
+++ b/account_invoice_triple_discount/migrations/16.0.2.0.0/post-migrate.py
@@ -16,8 +16,8 @@ def compute_discount(env):
         ]
     )
     for line in move_lines_to_compute:
-        discount = line._get_aggregated_discount_from_values(
-            {fname: line[fname] for fname in line._get_multiple_discount_field_names()}
+        discount = line._get_aggregated_multiple_discounts(
+            [line[x] for x in ["discount1", "discount2", "discount3"]]
         )
         rounded_discount = line._fields["discount"].convert_to_column(discount, line)
         openupgrade.logged_query(

--- a/account_invoice_triple_discount/models/account_move_line.py
+++ b/account_invoice_triple_discount/models/account_move_line.py
@@ -33,21 +33,16 @@ class AccountMoveLine(models.Model):
     @api.depends("discount1", "discount2", "discount3")
     def _compute_discount(self):
         for line in self:
-            line.discount = line._get_aggregated_discount_from_values(
-                {
-                    fname: line[fname]
-                    for fname in line._get_multiple_discount_field_names()
-                }
+            line.discount = line._get_aggregated_multiple_discounts(
+                [line[x] for x in line._get_multiple_discount_field_names()]
             )
 
-    def _get_aggregated_discount_from_values(self, values):
-        discount_fnames = self._get_multiple_discount_field_names()
-        discounts = []
-        for discount_fname in discount_fnames:
-            discounts.append(values.get(discount_fname) or 0.0)
-        return self._get_aggregated_multiple_discounts(discounts)
-
     def _get_aggregated_multiple_discounts(self, discounts):
+        """
+        Returns the aggregate discount corresponding to any number of discounts.
+        For exemple, if discounts is [11.0, 22.0, 33.0]
+        It will return 46.5114
+        """
         discount_values = []
         for discount in discounts:
             discount_values.append(1 - (discount or 0.0) / 100.0)
@@ -56,5 +51,6 @@ class AccountMoveLine(models.Model):
         ) * 100
         return aggregated_discount
 
+    @api.model
     def _get_multiple_discount_field_names(self):
         return ["discount1", "discount2", "discount3"]


### PR DESCRIPTION
Hi @grindtildeath. 

- I simplified a little the algorithm of account.move.line model. I removed the intermediary function ``_get_aggregated_discount_from_values`` that is finally useless.
- I added a comment for the function ``_get_aggregated_multiple_discounts`` that will be maybe used in the futur, by another module ``purchase_triple_discount``. 
- I added a post_init_hook to populate correctly discount1 field, if database contains not null discount values before the installation of the module.
